### PR TITLE
Fixes pylint `used-before-assignment` error

### DIFF
--- a/changelogs/fragments/pylint_fix.yaml
+++ b/changelogs/fragments/pylint_fix.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Fixes pylint used-before-assignment error in the health_check_view module.

--- a/plugins/filter/health_check_view.py
+++ b/plugins/filter/health_check_view.py
@@ -387,6 +387,7 @@ def health_check_view(*args, **kwargs):
         health_facts = _process_health_facts(health_facts["interfaces"])
 
     health_checks = {}
+    details = None
     if target["name"] == "health_check":
         h_vars = target.get("vars")
         if h_vars:


### PR DESCRIPTION
Fixes pylint `used-before-assignment` error in the `health_check_view` module.